### PR TITLE
fix: popup height

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,8 +2,11 @@
 
 html, body {
     font-family: Noto Sans KR, sans-serif;
+    min-width: 500px;
+    height: 475px;
 }
 
 #root {
-    min-width: 500px;
+    width: 100%;
+    height: 100%;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,6 @@ import styled from "styled-components";
 import {
     Button,
     Input,
-    Layout,
     PageHeader,
     Space,
     Spin,
@@ -25,7 +24,7 @@ import {
  * Internal modules
  */
 import "./App.css";
-import { AddressList, Header, Content, Footer } from "./components";
+import { AddressList, Content, Footer, Header, Layout } from "./components";
 import { AddressData, AddressManager } from "./AddressManager";
 import { SettingsManager, Settings } from "./SettingsManager";
 import { isExtension } from "./utils";

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@
 /**
  * External modules
  */
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import styled from "styled-components";
 import {
     Button,
@@ -109,6 +109,7 @@ export const App = (props: Props) => {
     const [showLegacyAddr, setShowLegacyAddr] = useState(true);
     const [addressData, setAddressData] = useState<AddressData[]>([]);
     const [updatingSettings, setUpdatingSettings] = useState(false);
+    const contentRef = useRef<HTMLElement>(null);
 
     const handleSearchValueChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
         setSearchValue(e.target.value);
@@ -226,9 +227,12 @@ export const App = (props: Props) => {
     ], [showEngAddr, showRoadAddr, showLegacyAddr, updatingSettings, handleSearchOptionClick]);
 
     const handleScrollEvent = useCallback(() => {
-        const list = document.getElementsByClassName("address-list");
-        const bottom = list[0]?.getBoundingClientRect().bottom ?? 0;
-        if (bottom > 0 && bottom <= window.innerHeight) {
+        const scrollContainer = document.getElementById("content");
+        if (!scrollContainer) {
+            return;
+        }
+
+        if (scrollContainer.scrollHeight - scrollContainer.scrollTop === scrollContainer.clientHeight) {
             console.log("scroll occurred");
             loadNextAddress();
         }
@@ -252,11 +256,12 @@ export const App = (props: Props) => {
     }, [settings]);
 
     useEffect(() => {
-        document.addEventListener("scroll", handleScrollEvent);
+        const scrollContainer = contentRef.current;
+        scrollContainer?.addEventListener("scroll", handleScrollEvent);
         return () => {
-            document.removeEventListener("scroll", handleScrollEvent);
+            scrollContainer?.removeEventListener("scroll", handleScrollEvent);
         };
-    }, [handleScrollEvent]);
+    }, [contentRef, handleScrollEvent]);
 
     return (
         <Layout>
@@ -272,7 +277,7 @@ export const App = (props: Props) => {
                         onSearch={handleSearchClick} />
                 </SearchWrapper>
             </Header>
-            <Content>
+            <Content id="content" ref={contentRef}>
                 <ListTop addressData={addressData} onResetClick={handleResetClick} />
                 <AddressList
                     data={addressData}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,7 +2,14 @@
  * External modules
  */
 import styled from "styled-components";
-import { Layout } from "antd";
+import { Layout as _Layout } from "antd";
+
+export const Layout = styled(_Layout)`
+    display: flex;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+`;
 
 export const Header = styled.div`
     position: fixed;
@@ -13,12 +20,14 @@ export const Header = styled.div`
     background-color: #f0f2f5;
 `;
 
-export const Content = styled(Layout.Content)`
+export const Content = styled(_Layout.Content)`
+    flex: 1;
     margin-top: 124px;
     background-color: #fafafa;
+    overflow: scroll;
 `;
 
-export const Footer = styled(Layout.Footer)`
+export const Footer = styled(_Layout.Footer)`
     display: flex;
     padding: 0 0 16px 0;
     justify-content: center;


### PR DESCRIPTION
## Description

Extension's layout does not use all available space in popup area. This issue is related to user's browser. Firefox only supports dynamic height of extension popup. So, I changed the popup height to have fixed value. (475px)

## Changes

- change popup height to 475px
- improve scroll end detection logic

This fixes #350 