### PR TITLE
fix: settings load logic

### DIFF
--- a/src/AddressManager.ts
+++ b/src/AddressManager.ts
@@ -46,13 +46,14 @@ export class AddressManager {
         this.settingsManager = settingsManager;
 
         if (this.settingsManager && isExtension()) {
-            const settings = this.settingsManager?.settings;
-            if (!settings) {
-                console.warn("AddressManager", "No settings found!");
-                return;
-            }
-            this.addressData = settings.addressData || [];
-            this.previousSearchKey = settings.prevSearchKey || DEFAULT_SETTINGS.prevSearchKey as SearchKey;
+            this.settingsManager.loadSettings().then((settings) => {
+                if (!settings) {
+                    console.warn("AddressManager", "No settings found!");
+                    return;
+                }
+                this.addressData = settings.addressData || [];
+                this.previousSearchKey = settings.prevSearchKey || DEFAULT_SETTINGS.prevSearchKey as SearchKey;
+            });
         }
     }
 

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -38,15 +38,13 @@ export class SettingsManager<T> {
     settings: T | null = null;
 
     constructor(defaultSettings: T) {
-        (async () => {
-            try {
-                this.settings = await this.loadSettings();
-            } catch (err) {
-                console.error(err);
-                this.settings = defaultSettings;
-                await chrome.storage.local.set(defaultSettings);
-            }
-        })();
+        this.loadSettings().then((settings) => {
+            this.settings = settings;
+        }).catch((err) => {
+            console.error(err);
+            this.settings = defaultSettings;
+            chrome.storage.local.set(defaultSettings);
+        });
     }
 
     get(key: keyof T) {
@@ -54,6 +52,10 @@ export class SettingsManager<T> {
     }
 
     async loadSettings() {
+        if (!isExtension()) {
+            return null;
+        }
+
         const settings = await chrome.storage.local.get(null);
         if (settings) {
             return settings as T;


### PR DESCRIPTION
## Description

AddressManager initially loads previous search history from SettingsManager. At the initial preparation time, AddressManager may not load settings even there are settings exist. I changed AddressManager to load settings explicitly.

This fixes #352 