### PR TITLE
chore: retarget release-automation workflow to release branch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,7 @@ on:
     types:
       - closed
     branches:
-      - main
+      - release
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Retargets `cd.yml`'s trigger from `branches: [main]` to `branches: [release]`, keeping the file on `main`.
- Adopting a two-branch strategy: `main` is pure development (CI only, this workflow stays inert here since no PR ever targets `release` from within `main`'s own history), `release` is the deployable branch. Promoting `main` → `release` via PR is what triggers the release automation.
- Supersedes the earlier approach in this PR (deleting the file from `main`) — keeping the file identical on both branches avoids reintroducing drift between them, which is the exact problem this branch-strategy cleanup is meant to fix. See #366 for context (now closed as redundant).

## Test plan
- [x] `ci.yml` (build + lint) is untouched and still runs on this branch
- [ ] Confirm no release/tag gets cut when this PR merges into main (branch filter shouldn't match, but flagging in case of a GitHub pull_request-workflow evaluation edge case)
- [ ] Next promotion PR from main → release should trigger build/bump-version/release-version as expected