### PR TITLE
chore: retarget release-automation workflow to release branch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,7 @@ on:
     types:
       - closed
     branches:
-      - main
+      - release
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Retargets `cd.yml`'s trigger from `branches: [main]` to `branches: [release]`.
- Companion to #365 (which removes the workflow from `main`). After both merge: `main` = development (CI only), `release` = deployable branch; promoting `main` → `release` via PR is what cuts a version bump + GitHub Release.

## Test plan
- [ ] Merge this after #365
- [ ] Next promotion PR from main → release should trigger build/bump-version/release-version as expected