### PR TITLE
Bring Sentry back online, with an error boundary

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,27 +1,30 @@
-// import * as Sentry from "@sentry/react";
-import React from "react";
+import * as Sentry from "@sentry/react";
 import ReactDOM from "react-dom/client";
 
 import { App } from "./App";
+import { isProduction } from "./shared/utils";
 
-// window.dataLayer = window.dataLayer || [];
-// if (isProduction()) {
-//   window.gtag = function (...args: any[]) {
-//     window.dataLayer.push(args);
-//   };
-//   window.gtag("config", "G-NJFP4YL0X3", {
-//     allow_google_signals: false,
-//     allow_ad_personalization_signals: false,
-//   });
-//   window.gtag("js", new Date());
-//   Sentry.init({
-//     dsn: "https://6b96accd47ff467da8394a51da93d909@o415139.ingest.sentry.io/5305794",
-//   });
-// } else {
-//   console.info(
-//     "Google Analytics disabled because runtime does not running in production."
-//   );
-//   window.gtag = function () {};
-// }
+if (isProduction()) {
+  Sentry.init({
+    dsn: "https://6b96accd47ff467da8394a51da93d909@o415139.ingest.sentry.io/5305794",
+      integrations: [
+      // If you're using react router, use the integration for your react router version instead.
+      // Learn more at
+      // https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/
+      Sentry.browserTracingIntegration(),
+    ],
+    // Set tracesSampleRate to 1.0 to capture 100%
+    // of transactions for tracing.
+    // Learn more at
+    // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
+    tracesSampleRate: 1.0,
+  });
+}
 
-ReactDOM.createRoot(document.getElementById("root")!).render(<App />);
+const ErrorFallback = () => <p style={{ padding: 16 }}>오류가 발생했습니다. 확장 프로그램을 다시 열어주세요.</p>;
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <Sentry.ErrorBoundary fallback={<ErrorFallback />}>
+    <App />
+  </Sentry.ErrorBoundary>,
+);


### PR DESCRIPTION
## Summary
Re-enables Sentry error tracking (SDK already upgraded in #367) and wraps the app in an error boundary so a crash doesn't blank the popup.

## The Changes
- `Sentry.init()` gated on `isProduction()`, reusing the existing DSN
- `browserTracingIntegration()`, `tracesSampleRate: 1.0`
- wrap `<App />` in `Sentry.ErrorBoundary` with a fallback UI
- remove dead commented-out GA/Sentry init block

## Package Changes
None — Sentry SDK version was already bumped in #367.

## Anything Else
Test plan:
- [x] `yarn build`
- [x] `yarn lint`
- [x] manual smoke test of built `dist/`: search works, `window.__SENTRY__` present, no console errors