### PR TITLE
fix: guard browser global access in getRuntime

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -23,9 +23,12 @@ export const isProduction = () => import.meta.env.PROD;
 
 export const getRuntime = (): Runtime => {
   try {
-    if (typeof chrome === "undefined" && typeof browser === "undefined") {
+    const hasChrome = typeof chrome !== "undefined";
+    const hasBrowser = typeof browser !== "undefined";
+
+    if (!hasChrome && !hasBrowser) {
       return "other";
-    } else if (chrome?.runtime?.id || browser?.runtime?.id) {
+    } else if ((hasChrome && chrome.runtime?.id) || (hasBrowser && browser.runtime?.id)) {
       return "extension";
     } else {
       return "page";


### PR DESCRIPTION
## Summary
- `browser?.runtime?.id` still throws ReferenceError when `browser` is undeclared (optional chaining only guards values, not identifiers) - true in every Chrome context, so the "page" branch was unreachable there and silently fell through to "unknown"
- guard each global behind its own typeof check instead

## Test plan
- [x] yarn build
- [x] yarn lint