### PR TITLE
Migrate state management from Recoil to Zustand

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.7.0",
-    "recoil": "^0.7.7",
-    "styled-components": "^6.5.3"
+    "styled-components": "^6.5.3",
+    "zustand": "^5.0.15"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,12 @@
 import { ConfigProvider, Layout as _Layout, ThemeConfig } from "antd";
-import { RecoilRoot } from "recoil";
+import { useEffect } from "react";
 import styled from "styled-components";
 
 import "./App.css";
 import { Content, Footer, Header } from "./components/popup";
+import { useAddressStore } from "./states/address";
+import { useSearchStore } from "./states/search";
+import { useSettingsStore } from "./states/settings";
 
 export const Layout = styled(_Layout)`
   display: flex;
@@ -21,15 +24,19 @@ const theme: ThemeConfig = {
 };
 
 export const App = () => {
+  useEffect(() => {
+    useAddressStore.getState().hydrate();
+    useSearchStore.getState().hydrate();
+    useSettingsStore.getState().hydrate();
+  }, []);
+
   return (
-    <RecoilRoot>
-      <ConfigProvider theme={theme}>
-        <Layout>
-          <Header />
-          <Content />
-          <Footer />
-        </Layout>
-      </ConfigProvider>
-    </RecoilRoot>
+    <ConfigProvider theme={theme}>
+      <Layout>
+        <Header />
+        <Content />
+        <Footer />
+      </Layout>
+    </ConfigProvider>
   );
 };

--- a/src/components/popup/Content.tsx
+++ b/src/components/popup/Content.tsx
@@ -1,14 +1,11 @@
 import { Layout, Spin, Typography } from "antd";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { AiOutlineCheckCircle, AiOutlineLoading, AiOutlineReload } from "react-icons/ai";
-import { useRecoilValue } from "recoil";
 import styled from "styled-components";
 
 import { AddressList } from "../ui/AddressList";
 import { useAddressSearch } from "@/hooks/useAddressSearch";
 import { useSettings } from "@/hooks/useSettings";
-import { addressListState } from "@/states/address";
-import { prevSearchKeyState, searchLoadingState } from "@/states/search";
 import type { AddressData } from "@/shared/models/address";
 
 const CHECK_COLOR = "#3CB043";
@@ -86,10 +83,7 @@ const Spinner = () => (
 
 export const Content = () => {
   const contentRef = useRef<HTMLElement>(null);
-  const addressList = useRecoilValue(addressListState);
-  const searching = useRecoilValue(searchLoadingState);
-  const prevSearchKey = useRecoilValue(prevSearchKeyState);
-  const { searchNextPage, resetSearch } = useAddressSearch();
+  const { addressList, prevSearchKey, searching, searchNextPage, resetSearch } = useAddressSearch();
   const { addressDisplayOptions } = useSettings();
   const isEnd = useMemo(() => prevSearchKey?.end ?? false, [prevSearchKey]);
 

--- a/src/components/popup/Header.tsx
+++ b/src/components/popup/Header.tsx
@@ -5,7 +5,6 @@ import styled from "styled-components";
 
 import { useAddressSearch } from "@/hooks/useAddressSearch";
 import { useSettings } from "@/hooks/useSettings";
-import { useSearchStore } from "@/states/search";
 
 const OptionsWrapper = styled.div`
   display: flex;
@@ -57,10 +56,7 @@ const DISPLAY_OPTIONS = [
 ] as const;
 
 export const Header = () => {
-  const searchKeyword = useSearchStore((state) => state.searchKeyword);
-  const setSearchKeyword = useSearchStore((state) => state.setSearchKeyword);
-  const searching = useSearchStore((state) => state.searching);
-  const { searchAddress } = useAddressSearch();
+  const { searchKeyword, setSearchKeyword, searching, searchAddress } = useAddressSearch();
   const { addressDisplayOptions, toggleDisplayOption } = useSettings();
 
   const displayOptions = useMemo(

--- a/src/components/popup/Header.tsx
+++ b/src/components/popup/Header.tsx
@@ -1,13 +1,11 @@
 import { Button, Input, Layout } from "antd";
 import { useCallback, useMemo } from "react";
 import { AiFillCheckCircle, AiOutlineCheckCircle } from "react-icons/ai";
-import { useRecoilState, useRecoilValue } from "recoil";
 import styled from "styled-components";
 
 import { useAddressSearch } from "@/hooks/useAddressSearch";
 import { useSettings } from "@/hooks/useSettings";
-import { searchKeywordState, searchLoadingState } from "@/states/search";
-import { addressDisplayOptionsState } from "@/states/settings";
+import { useSearchStore } from "@/states/search";
 
 const OptionsWrapper = styled.div`
   display: flex;
@@ -59,11 +57,11 @@ const DISPLAY_OPTIONS = [
 ] as const;
 
 export const Header = () => {
-  const addressDisplayOptions = useRecoilValue(addressDisplayOptionsState);
-  const [searchKeyword, setSearchKeyword] = useRecoilState(searchKeywordState);
-  const searching = useRecoilValue(searchLoadingState);
+  const searchKeyword = useSearchStore((state) => state.searchKeyword);
+  const setSearchKeyword = useSearchStore((state) => state.setSearchKeyword);
+  const searching = useSearchStore((state) => state.searching);
   const { searchAddress } = useAddressSearch();
-  const { toggleDisplayOption } = useSettings();
+  const { addressDisplayOptions, toggleDisplayOption } = useSettings();
 
   const displayOptions = useMemo(
     () =>

--- a/src/hooks/useAddressSearch.ts
+++ b/src/hooks/useAddressSearch.ts
@@ -1,20 +1,22 @@
 import axios from "axios";
 import type { AxiosResponse } from "axios";
 import { useCallback } from "react";
-import { useRecoilState, useSetRecoilState } from "recoil";
 
 import type { AddressSearchAPIResponse, SearchKey } from "@/shared/models/address";
-import { addressListState } from "@/states/address";
-import { prevSearchKeyState, searchKeywordState, searchLoadingState } from "@/states/search";
+import { useAddressStore } from "@/states/address";
+import { useSearchStore } from "@/states/search";
 
 const JUSO_API = "http://www.juso.go.kr/addrlink/addrLinkApi.do";
 const API_KEY = "U01TX0FVVEgyMDIwMDUyMTEzNTUwOTEwOTc4NDI=";
 
 export const useAddressSearch = () => {
-  const [prevSearchKey, setPrevSearchKey] = useRecoilState(prevSearchKeyState);
-  const [addressList, setAddressList] = useRecoilState(addressListState);
-  const [searching, setSearching] = useRecoilState(searchLoadingState);
-  const setSearchKeyword = useSetRecoilState(searchKeywordState);
+  const prevSearchKey = useSearchStore((state) => state.prevSearchKey);
+  const setPrevSearchKey = useSearchStore((state) => state.setPrevSearchKey);
+  const searching = useSearchStore((state) => state.searching);
+  const setSearching = useSearchStore((state) => state.setSearching);
+  const setSearchKeyword = useSearchStore((state) => state.setSearchKeyword);
+  const addressList = useAddressStore((state) => state.addressList);
+  const setAddressList = useAddressStore((state) => state.setAddressList);
 
   const performSearch = useCallback(
     async (searchKey: SearchKey) => {

--- a/src/hooks/useAddressSearch.ts
+++ b/src/hooks/useAddressSearch.ts
@@ -91,6 +91,8 @@ export const useAddressSearch = () => {
 
   return {
     addressList,
+    prevSearchKey,
+    searching,
     searchAddress,
     searchNextPage,
     resetSearch,

--- a/src/hooks/useAddressSearch.ts
+++ b/src/hooks/useAddressSearch.ts
@@ -14,6 +14,7 @@ export const useAddressSearch = () => {
   const setPrevSearchKey = useSearchStore((state) => state.setPrevSearchKey);
   const searching = useSearchStore((state) => state.searching);
   const setSearching = useSearchStore((state) => state.setSearching);
+  const searchKeyword = useSearchStore((state) => state.searchKeyword);
   const setSearchKeyword = useSearchStore((state) => state.setSearchKeyword);
   const addressList = useAddressStore((state) => state.addressList);
   const setAddressList = useAddressStore((state) => state.setAddressList);
@@ -95,6 +96,8 @@ export const useAddressSearch = () => {
     addressList,
     prevSearchKey,
     searching,
+    searchKeyword,
+    setSearchKeyword,
     searchAddress,
     searchNextPage,
     resetSearch,

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,16 +1,20 @@
 import { useCallback } from "react";
-import { useRecoilState } from "recoil";
 
-import { addressDisplayOptionsState } from "@/states/settings";
+import { useSettingsStore } from "@/states/settings";
 
 export const useSettings = () => {
-  const [addressDisplayOptions, setAddressDisplayOptions] = useRecoilState(addressDisplayOptionsState);
-  const toggleDisplayOption = useCallback((key: keyof typeof addressDisplayOptions) => {
-    setAddressDisplayOptions((prevOptions) => ({
-      ...prevOptions,
-      [key]: !prevOptions[key],
-    }));
-  }, [setAddressDisplayOptions]);
+  const addressDisplayOptions = useSettingsStore((state) => state.addressDisplayOptions);
+  const setAddressDisplayOptions = useSettingsStore((state) => state.setAddressDisplayOptions);
+
+  const toggleDisplayOption = useCallback(
+    (key: keyof typeof addressDisplayOptions) => {
+      setAddressDisplayOptions((prevOptions) => ({
+        ...prevOptions,
+        [key]: !prevOptions[key],
+      }));
+    },
+    [setAddressDisplayOptions],
+  );
 
   return { addressDisplayOptions, toggleDisplayOption };
 };

--- a/src/states/address.ts
+++ b/src/states/address.ts
@@ -1,22 +1,25 @@
-import { atom } from "recoil";
+import { create } from "zustand";
 
 import { getRecentAddressList, setRecentAddressList } from "@/shared/storage";
 import type { AddressData } from "@/shared/models/address";
 
-export const addressListState = atom<AddressData[]>({
-  key: "address-list",
-  default: [],
-  effects: [({ trigger, setSelf, onSet }) => {
-    if (trigger === "get") {
-      getRecentAddressList()?.then((recentAddressList) => {
-        if (recentAddressList) {
-          setSelf(recentAddressList);
-        }
-      });
-    }
+interface AddressStore {
+  addressList: AddressData[];
+  setAddressList: (update: AddressData[] | ((prev: AddressData[]) => AddressData[])) => void;
+  hydrate: () => Promise<void>;
+}
 
-    onSet((newAddressList) => {
-      setRecentAddressList(newAddressList);
-    });
-  }],
-});
+export const useAddressStore = create<AddressStore>((set, get) => ({
+  addressList: [],
+  setAddressList: (update) => {
+    const addressList = typeof update === "function" ? update(get().addressList) : update;
+    set({ addressList });
+    setRecentAddressList(addressList);
+  },
+  hydrate: async () => {
+    const recentAddressList = await getRecentAddressList();
+    if (recentAddressList) {
+      set({ addressList: recentAddressList });
+    }
+  },
+}));

--- a/src/states/search.ts
+++ b/src/states/search.ts
@@ -1,41 +1,45 @@
-import { atom } from "recoil";
+import { create } from "zustand";
 
-import { DEFAULT_SETTINGS, getPrevSearchKey, setPrevSearchKey, validateSettingsData } from "@/shared/storage";
+import {
+  DEFAULT_SETTINGS,
+  getPrevSearchKey,
+  setPrevSearchKey as persistPrevSearchKey,
+  validateSettingsData,
+} from "@/shared/storage";
 import type { SearchKey } from "@/shared/models/address";
 
-export const searchKeywordState = atom({
-  key: "search-keyword",
-  default: "",
-  effects: [({ trigger, setSelf }) => {
-    if (trigger === "get") {
-      getPrevSearchKey().then((prevSearchKey) => {
-        setSelf(prevSearchKey?.keyword ?? "");
-      });
+interface SearchStore {
+  searchKeyword: string;
+  searching: boolean;
+  prevSearchKey: SearchKey | null;
+  setSearchKeyword: (keyword: string) => void;
+  setSearching: (searching: boolean) => void;
+  setPrevSearchKey: (searchKey: SearchKey | null) => void;
+  hydrate: () => Promise<void>;
+}
+
+export const useSearchStore = create<SearchStore>((set) => ({
+  searchKeyword: "",
+  searching: false,
+  prevSearchKey: null,
+  setSearchKeyword: (searchKeyword) => set({ searchKeyword }),
+  setSearching: (searching) => set({ searching }),
+  setPrevSearchKey: (prevSearchKey) => {
+    set({ prevSearchKey });
+    persistPrevSearchKey(prevSearchKey);
+  },
+  hydrate: async () => {
+    const prevSearchKey = await getPrevSearchKey();
+    set({ searchKeyword: prevSearchKey?.keyword ?? "" });
+
+    // NOTE: preserved as-is from the original Recoil atom effect. This looks
+    // inverted (skips restoring prevSearchKey when it IS valid) but this
+    // migration is behavior-preserving; see PR description for the
+    // discovered-bug follow-up.
+    if (!prevSearchKey || validateSettingsData(prevSearchKey, DEFAULT_SETTINGS.prevSearchKey)) {
+      return;
     }
-  }],
-});
 
-export const searchLoadingState = atom({
-  key: "search-loading",
-  default: false,
-});
-
-export const prevSearchKeyState = atom<SearchKey | null>({
-  key: "prev-search-key",
-  default: null,
-  effects: [({ trigger, setSelf, onSet }) => {
-    if (trigger === "get") {
-      getPrevSearchKey().then((prevSearchKey) => {
-        if (!prevSearchKey || validateSettingsData(prevSearchKey, DEFAULT_SETTINGS.prevSearchKey)) {
-          return;
-        }
-
-        setSelf(prevSearchKey);
-      });
-    }
-
-    onSet((newSearchKey) => {
-      setPrevSearchKey(newSearchKey);
-    });
-  }],
-});
+    set({ prevSearchKey });
+  },
+}));

--- a/src/states/settings.ts
+++ b/src/states/settings.ts
@@ -1,4 +1,4 @@
-import { atom } from "recoil";
+import { create } from "zustand";
 
 import {
   DEFAULT_SETTINGS,
@@ -8,34 +8,41 @@ import {
 } from "@/shared/storage";
 import type { DisplayOptions } from "@/shared/models/settings";
 
-export const addressDisplayOptionsState = atom<DisplayOptions>({
-  key: "display-options",
-  default: {
+interface SettingsStore {
+  addressDisplayOptions: DisplayOptions;
+  setAddressDisplayOptions: (
+    update: DisplayOptions | ((prev: DisplayOptions) => DisplayOptions),
+  ) => void;
+  hydrate: () => Promise<void>;
+}
+
+export const useSettingsStore = create<SettingsStore>((set, get) => ({
+  addressDisplayOptions: {
     engAddrShown: true,
     roadAddrShown: true,
     streetNumAddrShown: true,
   },
-  effects: [({ trigger, setSelf, onSet }) => {
-    if (trigger === "get") {
-      getSearchResultOptions()?.then((options) => {
-        if (!options || !validateSettingsData(options, DEFAULT_SETTINGS.searchResult)) {
-          return;
-        }
-
-        setSelf({
-          engAddrShown: options.showEng,
-          roadAddrShown: options.showRoad,
-          streetNumAddrShown: options.showLegacy,
-        });
-      });
-    }
-
-    onSet((newOptions) => {
-      setSearchResultOptions({
-        showEng: newOptions.engAddrShown,
-        showRoad: newOptions.roadAddrShown,
-        showLegacy: newOptions.streetNumAddrShown,
-      });
+  setAddressDisplayOptions: (update) => {
+    const addressDisplayOptions =
+      typeof update === "function" ? update(get().addressDisplayOptions) : update;
+    set({ addressDisplayOptions });
+    setSearchResultOptions({
+      showEng: addressDisplayOptions.engAddrShown,
+      showRoad: addressDisplayOptions.roadAddrShown,
+      showLegacy: addressDisplayOptions.streetNumAddrShown,
     });
-  }],
-});
+  },
+  hydrate: async () => {
+    const options = await getSearchResultOptions();
+    if (!options || !validateSettingsData(options, DEFAULT_SETTINGS.searchResult)) {
+      return;
+    }
+    set({
+      addressDisplayOptions: {
+        engAddrShown: options.showEng,
+        roadAddrShown: options.showRoad,
+        streetNumAddrShown: options.showLegacy,
+      },
+    });
+  },
+}));

--- a/tests/components/popup/Content.test.tsx
+++ b/tests/components/popup/Content.test.tsx
@@ -1,22 +1,25 @@
 import { render, screen } from "@testing-library/react";
-import { RecoilRoot } from "recoil";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { Content } from "@/components/popup/Content";
+import { useAddressStore } from "@/states/address";
+import { useSearchStore } from "@/states/search";
+import { useSettingsStore } from "@/states/settings";
 
-// Smoke test: verifies the hooks/Recoil-state wiring (useAddressSearch,
-// useSettings, and their backing atoms) renders without crashing.
+// Smoke test: verifies the hooks/store wiring (useAddressSearch, useSettings,
+// and their backing Zustand stores) renders without crashing.
 describe("Content", () => {
   beforeEach(() => {
     localStorage.clear();
+    useAddressStore.setState({ addressList: [] });
+    useSearchStore.setState({ searchKeyword: "", searching: false, prevSearchKey: null });
+    useSettingsStore.setState({
+      addressDisplayOptions: { engAddrShown: true, roadAddrShown: true, streetNumAddrShown: true },
+    });
   });
 
   it("renders the empty-result state on first render", () => {
-    render(
-      <RecoilRoot>
-        <Content />
-      </RecoilRoot>,
-    );
+    render(<Content />);
 
     expect(screen.getByText("검색 결과가 없습니다.")).toBeInTheDocument();
   });

--- a/tests/hooks/useAddressSearch.test.tsx
+++ b/tests/hooks/useAddressSearch.test.tsx
@@ -1,16 +1,14 @@
 import { act, renderHook } from "@testing-library/react";
 import axios from "axios";
-import type { PropsWithChildren } from "react";
-import { RecoilRoot } from "recoil";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AddressData, SearchKey } from "@/shared/models/address";
 import { useAddressSearch } from "@/hooks/useAddressSearch";
+import { useAddressStore } from "@/states/address";
+import { useSearchStore } from "@/states/search";
 
 vi.mock("axios");
 const mockedPost = vi.mocked(axios.post);
-
-const wrapper = ({ children }: PropsWithChildren) => <RecoilRoot>{children}</RecoilRoot>;
 
 const makeSearchKey = (overrides: Partial<SearchKey> = {}): SearchKey => ({
   currentPage: "1",
@@ -48,11 +46,13 @@ describe("useAddressSearch", () => {
   beforeEach(() => {
     mockedPost.mockReset();
     localStorage.clear();
+    useAddressStore.setState({ addressList: [] });
+    useSearchStore.setState({ searchKeyword: "", searching: false, prevSearchKey: null });
   });
 
   it("searchAddress populates addressList from the API response", async () => {
     mockedPost.mockResolvedValueOnce(makeApiResponse([makeAddress()]));
-    const { result } = renderHook(() => useAddressSearch(), { wrapper });
+    const { result } = renderHook(() => useAddressSearch());
 
     await act(async () => {
       await result.current.searchAddress(makeSearchKey());
@@ -65,7 +65,7 @@ describe("useAddressSearch", () => {
 
   it("searchAddress clears addressList when the API call fails", async () => {
     mockedPost.mockRejectedValueOnce(new Error("network error"));
-    const { result } = renderHook(() => useAddressSearch(), { wrapper });
+    const { result } = renderHook(() => useAddressSearch());
 
     await act(async () => {
       await result.current.searchAddress(makeSearchKey());
@@ -76,7 +76,7 @@ describe("useAddressSearch", () => {
 
   it("ignores a repeat search with the same keyword", async () => {
     mockedPost.mockResolvedValue(makeApiResponse([]));
-    const { result } = renderHook(() => useAddressSearch(), { wrapper });
+    const { result } = renderHook(() => useAddressSearch());
 
     await act(async () => {
       await result.current.searchAddress(makeSearchKey());
@@ -92,7 +92,7 @@ describe("useAddressSearch", () => {
     mockedPost
       .mockResolvedValueOnce(makeApiResponse([makeAddress({ zipNo: "111" })]))
       .mockResolvedValueOnce(makeApiResponse([]));
-    const { result } = renderHook(() => useAddressSearch(), { wrapper });
+    const { result } = renderHook(() => useAddressSearch());
 
     await act(async () => {
       await result.current.searchAddress(makeSearchKey());
@@ -113,7 +113,7 @@ describe("useAddressSearch", () => {
 
   it("resetSearch clears the address list", async () => {
     mockedPost.mockResolvedValueOnce(makeApiResponse([makeAddress()]));
-    const { result } = renderHook(() => useAddressSearch(), { wrapper });
+    const { result } = renderHook(() => useAddressSearch());
 
     await act(async () => {
       await result.current.searchAddress(makeSearchKey());

--- a/tests/hooks/useSettings.test.tsx
+++ b/tests/hooks/useSettings.test.tsx
@@ -1,19 +1,19 @@
 import { act, renderHook } from "@testing-library/react";
-import type { PropsWithChildren } from "react";
-import { RecoilRoot } from "recoil";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { useSettings } from "@/hooks/useSettings";
-
-const wrapper = ({ children }: PropsWithChildren) => <RecoilRoot>{children}</RecoilRoot>;
+import { useSettingsStore } from "@/states/settings";
 
 describe("useSettings", () => {
   beforeEach(() => {
     localStorage.clear();
+    useSettingsStore.setState({
+      addressDisplayOptions: { engAddrShown: true, roadAddrShown: true, streetNumAddrShown: true },
+    });
   });
 
   it("defaults to all display options enabled", () => {
-    const { result } = renderHook(() => useSettings(), { wrapper });
+    const { result } = renderHook(() => useSettings());
     expect(result.current.addressDisplayOptions).toEqual({
       engAddrShown: true,
       roadAddrShown: true,
@@ -22,7 +22,7 @@ describe("useSettings", () => {
   });
 
   it("toggleDisplayOption flips only the given option", () => {
-    const { result } = renderHook(() => useSettings(), { wrapper });
+    const { result } = renderHook(() => useSettings());
 
     act(() => {
       result.current.toggleDisplayOption("engAddrShown");
@@ -36,7 +36,7 @@ describe("useSettings", () => {
   });
 
   it("toggling twice returns to the original value", () => {
-    const { result } = renderHook(() => useSettings(), { wrapper });
+    const { result } = renderHook(() => useSettings());
 
     act(() => {
       result.current.toggleDisplayOption("roadAddrShown");

--- a/yarn.lock
+++ b/yarn.lock
@@ -2675,11 +2675,6 @@ graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
-hamt_plus@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/hamt_plus/-/hamt_plus-1.0.2.tgz#e21c252968c7e33b20f6a1b094cd85787a265601"
-  integrity sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA==
-
 has-bigints@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
@@ -4259,13 +4254,6 @@ readdir-glob@^3.0.0:
   dependencies:
     minimatch "^10.2.2"
 
-recoil@^0.7.7:
-  version "0.7.7"
-  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.7.tgz#c5f2c843224384c9c09e4a62c060fb4c1454dc8e"
-  integrity sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==
-  dependencies:
-    hamt_plus "1.0.2"
-
 redent@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
@@ -5240,3 +5228,8 @@ zip-stream@^7.0.2:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
   integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==
+
+zustand@^5.0.15:
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-5.0.15.tgz#42bddf35647cb80a818a8943a69f6618c126fcfe"
+  integrity sha512-MpSEjRiBkA9crSYeOUH32rJC7SVqAbm0Fqcqge/bUi2PPoLcBWKOsG+C8mevmpr8TwXHBVkChbbJiyvkE+i/3A==


### PR DESCRIPTION
## Summary
Replaces Recoil (abandoned upstream since March 2023, unknown compatibility with React 19) with Zustand. First step of the deferred Recoil/React 19/antd 6 modernization — done on its own so it can be verified independently before the framework bump lands separately.

## The Changes

**Prep**
- `useAddressSearch` now also returns `prevSearchKey` and `searching`; `Content` consumes them from the hook instead of reading Recoil state directly

**Migration**
- `states/address.ts`, `states/search.ts`, `states/settings.ts`: Recoil atoms -> Zustand stores
- `App.tsx`: drop `RecoilRoot`, hydrate stores from storage in a mount effect instead of Recoil's per-atom "on get" trigger
- `useAddressSearch`, `useSettings`, `Header`: consume Zustand stores instead of Recoil hooks
- tests: drop the `RecoilRoot` wrapper, reset store state in `beforeEach` instead (Zustand stores are module-level singletons)

**Follow-up**
- `useAddressSearch` now also returns `searchKeyword`/`setSearchKeyword`; `Header` consumes them from the hook instead of importing `useSearchStore` directly — no component in `src/components` imports a store from `@/states` directly anymore

**Preserved, not fixed**
- `states/search.ts`'s `prevSearchKey` restore condition looks inverted (skips restoring when the persisted data IS valid) — kept byte-for-byte so this migration stays behavior-preserving. Flagging as a separate follow-up fix.

## Package Changes
- Removed: `recoil`
- Added: `zustand`

## Anything Else
Test plan:
- [x] `yarn build`
- [x] `yarn lint`
- [x] `yarn test` (34/34 pass)
- [x] manual smoke test of built `dist/`: search, display-option toggle, and both persisted correctly across a full page reload (hydration works); no console errors