### PR TITLE
Raise the chunk-size warning threshold and explain why

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,11 @@ export default defineConfig({
   },
   build: {
     outDir: "build",
+    // This is a single-view extension popup loaded from local files, not a
+    // network-served multi-page app - there's no route to code-split around,
+    // so the default 500kB warning is a false positive here. Current output
+    // is ~900kB; this leaves headroom before warning on genuine bloat.
+    chunkSizeWarningLimit: 1000,
   },
   resolve: {
     alias: [{ find: "@", replacement: path.join(import.meta.dirname, "src") }],


### PR DESCRIPTION
## Summary
Silences the yarn build "chunk larger than 500kB" warning, which is a false positive for this project's shape: a single-view extension popup loaded from local files, not a network-served multi-page app with routes to code-split around.

## The Changes
- `vite.config.ts`: `build.chunkSizeWarningLimit` raised to 1000 (current output is ~888KB / ~289KB gzip), with a comment explaining why

## Package Changes
None. (Analysis used `rollup-plugin-visualizer` locally to see what's contributing most to bundle size — added, inspected, then removed; not part of this diff.)

## Anything Else
Bundle composition found during analysis (pre-minify additive sizes, so proportions are directional):
- antd (+ rc-*/@ant-design/* ecosystem): ~33%
- @sentry/* tracing (core + browser + browser-utils): ~18% — largely `browserTracingIntegration()`
- react-dom: ~10%
- recoil: ~9.5% — already being removed in #374
- @babel/runtime: ~7% — transitive, not directly controllable
- axios: ~5.6% — native `fetch()` could drop this, but that's a behavior change, not in scope here

Test plan:
- [x] `yarn build` (warning gone)
- [x] `yarn lint`
- [x] `yarn test` (34/34 pass)