### PR TITLE
Add search history data layer

### DIFF
--- a/apps/popup/App.tsx
+++ b/apps/popup/App.tsx
@@ -5,6 +5,7 @@ import styled from "styled-components";
 import "./App.css";
 import { Content, Footer, Header } from "./components";
 import { useAddressStore } from "@shared/states/address";
+import { useSearchHistoryStore } from "@shared/states/history";
 import { useSearchStore } from "@shared/states/search";
 import { useSettingsStore } from "@shared/states/settings";
 
@@ -28,6 +29,7 @@ export const App = () => {
     useAddressStore.getState().hydrate();
     useSearchStore.getState().hydrate();
     useSettingsStore.getState().hydrate();
+    useSearchHistoryStore.getState().hydrate();
   }, []);
 
   return (

--- a/shared/hooks/useAddressSearch.ts
+++ b/shared/hooks/useAddressSearch.ts
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 
 import type { AddressSearchAPIResponse, SearchKey } from "@shared/models/address";
 import { useAddressStore } from "@shared/states/address";
+import { useSearchHistoryStore } from "@shared/states/history";
 import { useSearchStore } from "@shared/states/search";
 
 const JUSO_API = "http://www.juso.go.kr/addrlink/addrLinkApi.do";
@@ -51,6 +52,7 @@ export const useAddressSearch = () => {
       try {
         const searchResult = await performSearch(searchKey);
         setAddressList(searchResult?.juso || []);
+        useSearchHistoryStore.getState().addKeyword(searchKey.keyword);
       } catch (err) {
         console.error(err);
         setAddressList([]);

--- a/shared/models/history.ts
+++ b/shared/models/history.ts
@@ -1,0 +1,4 @@
+export type SearchHistoryLimit = {
+  enabled: boolean; // false = unlimited
+  value: number;    // retained even while enabled is false
+};

--- a/shared/states/history.ts
+++ b/shared/states/history.ts
@@ -1,0 +1,57 @@
+import { create } from "zustand";
+
+import {
+  getSearchHistory,
+  getSearchHistoryLimit,
+  setSearchHistory as persistSearchHistory,
+  setSearchHistoryLimit as persistSearchHistoryLimit,
+} from "@shared/storage";
+import type { SearchHistoryLimit } from "@shared/models/history";
+
+interface SearchHistoryStore {
+  history: string[];
+  searchHistoryLimit: SearchHistoryLimit;
+  addKeyword: (keyword: string) => void;
+  setSearchHistoryLimit: (
+    update: SearchHistoryLimit | ((prev: SearchHistoryLimit) => SearchHistoryLimit),
+  ) => void;
+  clearHistory: () => void;
+  hydrate: () => Promise<void>;
+}
+
+export const useSearchHistoryStore = create<SearchHistoryStore>((set, get) => ({
+  history: [],
+  searchHistoryLimit: { enabled: true, value: 50 },
+  addKeyword: (keyword) => {
+    const { history, searchHistoryLimit } = get();
+    const deduped = history.filter((entry) => entry !== keyword);
+    let next = [keyword, ...deduped];
+    if (searchHistoryLimit.enabled) {
+      next = next.slice(0, searchHistoryLimit.value);
+    }
+    set({ history: next });
+    persistSearchHistory(next);
+  },
+  setSearchHistoryLimit: (update) => {
+    const searchHistoryLimit =
+      typeof update === "function" ? update(get().searchHistoryLimit) : update;
+    set({ searchHistoryLimit });
+    persistSearchHistoryLimit(searchHistoryLimit);
+  },
+  clearHistory: () => {
+    set({ history: [] });
+    persistSearchHistory([]);
+  },
+  hydrate: async () => {
+    const [history, searchHistoryLimit] = await Promise.all([
+      getSearchHistory(),
+      getSearchHistoryLimit(),
+    ]);
+    if (history) {
+      set({ history });
+    }
+    if (searchHistoryLimit) {
+      set({ searchHistoryLimit });
+    }
+  },
+}));

--- a/shared/storage.ts
+++ b/shared/storage.ts
@@ -1,4 +1,5 @@
 import type { AddressData, SearchKey } from "./models/address";
+import type { SearchHistoryLimit } from "./models/history";
 import { isExtension, getExtensionAPI } from "./utils";
 
 type SearchResultOptions = {
@@ -11,6 +12,8 @@ export type Settings = Partial<{
   searchResult: Partial<SearchResultOptions>;
   addressData: AddressData[];
   prevSearchKey: SearchKey;
+  searchHistory: string[];
+  searchHistoryLimit: SearchHistoryLimit;
 }>;
 
 export const DEFAULT_SETTINGS: Settings = {
@@ -25,6 +28,11 @@ export const DEFAULT_SETTINGS: Settings = {
     currentPage: "1",
     keyword: "",
     end: false,
+  },
+  searchHistory: [],
+  searchHistoryLimit: {
+    enabled: true,
+    value: 50,
   },
 };
 
@@ -90,6 +98,24 @@ export const setRecentAddressList = async (addressList: AddressData[]) => {
 
 export const setPrevSearchKey = async (prevSearchKey: SearchKey | null) => {
   set({ prevSearchKey });
+};
+
+export const getSearchHistory = async (): Promise<string[] | null> => {
+  const searchHistory = await get("searchHistory");
+  return searchHistory?.searchHistory ?? null;
+};
+
+export const setSearchHistory = async (history: string[]) => {
+  set({ searchHistory: history });
+};
+
+export const getSearchHistoryLimit = async (): Promise<SearchHistoryLimit | null> => {
+  const searchHistoryLimit = await get("searchHistoryLimit");
+  return searchHistoryLimit?.searchHistoryLimit ?? null;
+};
+
+export const setSearchHistoryLimit = async (limit: SearchHistoryLimit) => {
+  set({ searchHistoryLimit: limit });
 };
 
 export const validateSettingsData = (

--- a/tests/shared/hooks/useAddressSearch.test.tsx
+++ b/tests/shared/hooks/useAddressSearch.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AddressData, SearchKey } from "@shared/models/address";
 import { useAddressSearch } from "@shared/hooks/useAddressSearch";
 import { useAddressStore } from "@shared/states/address";
+import { useSearchHistoryStore } from "@shared/states/history";
 import { useSearchStore } from "@shared/states/search";
 
 vi.mock("axios");
@@ -48,6 +49,7 @@ describe("useAddressSearch", () => {
     localStorage.clear();
     useAddressStore.setState({ addressList: [] });
     useSearchStore.setState({ searchKeyword: "", searching: false, prevSearchKey: null });
+    useSearchHistoryStore.setState({ history: [], searchHistoryLimit: { enabled: true, value: 50 } });
   });
 
   it("searchAddress populates addressList from the API response", async () => {
@@ -125,5 +127,32 @@ describe("useAddressSearch", () => {
     });
 
     expect(result.current.addressList).toEqual([]);
+  });
+
+  it("adds the keyword to search history on a successful new search", async () => {
+    mockedPost.mockResolvedValueOnce(makeApiResponse([makeAddress()]));
+    const { result } = renderHook(() => useAddressSearch());
+
+    await act(async () => {
+      await result.current.searchAddress(makeSearchKey({ keyword: "강남대로" }));
+    });
+
+    expect(useSearchHistoryStore.getState().history).toEqual(["강남대로"]);
+  });
+
+  it("does not add a keyword to history on searchNextPage", async () => {
+    mockedPost
+      .mockResolvedValueOnce(makeApiResponse([makeAddress({ zipNo: "111" })]))
+      .mockResolvedValueOnce(makeApiResponse([]));
+    const { result } = renderHook(() => useAddressSearch());
+
+    await act(async () => {
+      await result.current.searchAddress(makeSearchKey({ keyword: "강남대로" }));
+    });
+    await act(async () => {
+      await result.current.searchNextPage();
+    });
+
+    expect(useSearchHistoryStore.getState().history).toEqual(["강남대로"]);
   });
 });

--- a/tests/shared/states/history.test.ts
+++ b/tests/shared/states/history.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useSearchHistoryStore } from "@shared/states/history";
+
+describe("useSearchHistoryStore", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useSearchHistoryStore.setState({
+      history: [],
+      searchHistoryLimit: { enabled: true, value: 50 },
+    });
+  });
+
+  it("addKeyword adds a new keyword to the front", () => {
+    useSearchHistoryStore.getState().addKeyword("강남대로");
+    expect(useSearchHistoryStore.getState().history).toEqual(["강남대로"]);
+  });
+
+  it("addKeyword dedupes by moving a repeat to the front", () => {
+    const { addKeyword } = useSearchHistoryStore.getState();
+    addKeyword("강남대로");
+    addKeyword("자양동");
+    addKeyword("강남대로");
+    expect(useSearchHistoryStore.getState().history).toEqual(["강남대로", "자양동"]);
+  });
+
+  it("addKeyword truncates past the limit when enabled", () => {
+    useSearchHistoryStore.setState({ searchHistoryLimit: { enabled: true, value: 2 } });
+    const { addKeyword } = useSearchHistoryStore.getState();
+    addKeyword("a");
+    addKeyword("b");
+    addKeyword("c");
+    expect(useSearchHistoryStore.getState().history).toEqual(["c", "b"]);
+  });
+
+  it("addKeyword does not truncate when the limit is disabled", () => {
+    useSearchHistoryStore.setState({ searchHistoryLimit: { enabled: false, value: 2 } });
+    const { addKeyword } = useSearchHistoryStore.getState();
+    addKeyword("a");
+    addKeyword("b");
+    addKeyword("c");
+    expect(useSearchHistoryStore.getState().history).toEqual(["c", "b", "a"]);
+  });
+
+  it("setSearchHistoryLimit toggling enabled off then on retains the value", () => {
+    const { setSearchHistoryLimit } = useSearchHistoryStore.getState();
+    setSearchHistoryLimit({ enabled: true, value: 10 });
+    setSearchHistoryLimit((prev) => ({ ...prev, enabled: false }));
+    expect(useSearchHistoryStore.getState().searchHistoryLimit).toEqual({ enabled: false, value: 10 });
+    setSearchHistoryLimit((prev) => ({ ...prev, enabled: true }));
+    expect(useSearchHistoryStore.getState().searchHistoryLimit).toEqual({ enabled: true, value: 10 });
+  });
+
+  it("clearHistory empties the list", () => {
+    const { addKeyword, clearHistory } = useSearchHistoryStore.getState();
+    addKeyword("강남대로");
+    clearHistory();
+    expect(useSearchHistoryStore.getState().history).toEqual([]);
+  });
+
+  it("hydrate loads persisted history and limit", async () => {
+    useSearchHistoryStore.getState().addKeyword("강남대로");
+    useSearchHistoryStore.setState({
+      history: [],
+      searchHistoryLimit: { enabled: true, value: 50 },
+    });
+    await useSearchHistoryStore.getState().hydrate();
+    expect(useSearchHistoryStore.getState().history).toEqual(["강남대로"]);
+  });
+});

--- a/tests/shared/storage.test.ts
+++ b/tests/shared/storage.test.ts
@@ -5,9 +5,13 @@ import {
   getAllStorageData,
   getPrevSearchKey,
   getRecentAddressList,
+  getSearchHistory,
+  getSearchHistoryLimit,
   getSearchResultOptions,
   setPrevSearchKey,
   setRecentAddressList,
+  setSearchHistory,
+  setSearchHistoryLimit,
   setSearchResultOptions,
   validateSettingsData,
 } from "@shared/storage";
@@ -54,6 +58,21 @@ describe("storage (localStorage fallback)", () => {
     await setSearchResultOptions({ showEng: true, showRoad: true, showLegacy: true });
     const all = await getAllStorageData();
     expect(all.searchResult).toEqual({ showEng: true, showRoad: true, showLegacy: true });
+  });
+
+  it("returns null for search history that has not been stored yet", async () => {
+    expect(await getSearchHistory()).toBeNull();
+    expect(await getSearchHistoryLimit()).toBeNull();
+  });
+
+  it("round-trips the search history list through localStorage", async () => {
+    await setSearchHistory(["강남대로", "자양동"]);
+    expect(await getSearchHistory()).toEqual(["강남대로", "자양동"]);
+  });
+
+  it("round-trips the search history limit through localStorage", async () => {
+    await setSearchHistoryLimit({ enabled: false, value: 50 });
+    expect(await getSearchHistoryLimit()).toEqual({ enabled: false, value: 50 });
   });
 });
 


### PR DESCRIPTION
## Summary
Adds the search-keyword history feature's data layer: storage, Zustand store, and wiring into useAddressSearch. No UI yet - the options page (which surfaces this) lands in a later PR.

Stacked on #376 (directory restructure) - base branch here is refactor/split-apps-shared, not main. GitHub will retarget this to main automatically once #376 merges.

## The Changes
- shared/models/history.ts: SearchHistoryLimit type ({ enabled, value } - value retained when enabled toggles off)
- shared/storage.ts: getSearchHistory/setSearchHistory, getSearchHistoryLimit/setSearchHistoryLimit
- shared/states/history.ts: useSearchHistoryStore (addKeyword dedup+cap, setSearchHistoryLimit, clearHistory, hydrate)
- useAddressSearch.searchAddress calls addKeyword on a successful new search (not searchNextPage)
- apps/popup/App.tsx hydrates the new store on mount

## Package Changes
None.

## Anything Else
Test plan:
- [x] yarn build
- [x] yarn lint
- [x] yarn test (46/46 pass)